### PR TITLE
Add mysql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eventbrite Scraper
 
-A Python 3+ scraper that pulls USA event data from Eventbrite. The data is persisted to an `events.db` sqlite3
-database as well as output to stdout upon retrieving the values.
+A Python 3+ scraper that pulls USA event data from Eventbrite. The data is persisted to an `events.db` sqlite3 or MySQL
+database as well as outputs the found events to stdout.
 
 ### Installation
 
@@ -41,6 +41,8 @@ $ python scraper.py jazz chicago il
 19. SSMA presents SENSES to SOUL School of MusicSSMA presents SENSES to SOUL School of Music on Fri, June 25, 2021 7:00 PM – 9:30 PM CDT, event page: https://www.eventbrite.com/e/ssma-presents-senses-to-soul-school-of-music-tickets-157527861073?aff=ebdssbdestsearch
 20. Saxophonist Isaiah Collier & The Chosen FewSaxophonist Isaiah Collier & The Chosen Few on Fri, June 25, 2021 8:00 PM – 9:30 PM CDT, event page: https://www.eventbrite.com/e/saxophonist-isaiah-collier-the-chosen-few-tickets-156573207679?aff=ebdssbdestsearch
 ```
+
+If you'd like to output the data into a MySQL database use the `-d` flag,  for example: `python scraper.py jazz chicago il -d mysql`.
 
 If you need help on the usage run: `python scraper.py -h`.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ python scraper.py jazz chicago il
 
 If you need help on the usage run: `python scraper.py -h`.
 
-### Using a MySQL database
+## Using a MySQL database
 
 To use MySQL you'll need to create a `.env` file that has the following values: `DATABASE_USER` and `DATABASE_PASSWORD`.
 For information on setting up MySQL you can read the docs [here](https://dev.mysql.com/doc/mysql-installer/en/).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ database as well as outputs the found events to stdout.
 To use, you will need to specify a category, a city, and a two letter USA state abbreviation. 
 
 For example: `python scraper.py jazz chicago il`.
-If you'd like to specify the number of events (in multiples of 20), you can add an optional `-n` parameter:
-`python scraper.py jazz chicago il -n 40`.
 
 Example:
 
@@ -42,15 +40,36 @@ $ python scraper.py jazz chicago il
 20. Saxophonist Isaiah Collier & The Chosen FewSaxophonist Isaiah Collier & The Chosen Few on Fri, June 25, 2021 8:00 PM – 9:30 PM CDT, event page: https://www.eventbrite.com/e/saxophonist-isaiah-collier-the-chosen-few-tickets-156573207679?aff=ebdssbdestsearch
 ```
 
-If you'd like to output the data into a MySQL database use the `-d` flag,  for example: `python scraper.py jazz chicago il -d mysql`.
+**Optional Parameters**
+
+- *number* - You can specify the number of events (in multiples of 20) -- 20 is the default -- with the optional `-n` parameter: `python scraper.py jazz chicago il -n 40`.
+- *database* - You can specify the database -- `sqlite` or `mysql`, set to `sqlite` as default -- with the optional `-d` parameter: `python scraper.py jazz chicago il -d mysql`.
 
 If you need help on the usage run: `python scraper.py -h`.
 
-You can query the data with the sqlite3 command line utility:
+### Using a MySQL database
+
+To use MySQL you'll need to create a `.env` file that has the following values: `DATABASE_USER` and `DATABASE_PASSWORD`.
+For information on setting up MySQL you can read the docs [here](https://dev.mysql.com/doc/mysql-installer/en/).
+
+## Querying the data
+
+Depending on the database flavor you choose, you can can query the data with with the database flavor's command line utility:
+
+For example with `sqlite`:
 
 ```
 $ sqlite3
-> .open events.db
+> .open all_events.db
+> select count(*) from all_events;
+20
+```
+
+Or with `mysql`:
+
+```
+$ mysql -u USERNAME -p PASSWORD
+> use database all_events;
 > select count(*) from events;
 20
 ```

--- a/db.py
+++ b/db.py
@@ -1,0 +1,135 @@
+import pathlib
+import sqlite3
+from abc import abstractmethod
+from os import getenv
+
+from enum import Enum
+from mysql.connector import connect, Error, ProgrammingError
+
+
+SCRIPT_DIR = pathlib.Path(__file__).parent.absolute()
+
+
+class DatabaseMixin:
+    @abstractmethod
+    def connect_to_database(self, database_name, database_exist):
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_tables(self, queries):
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert(self, query, data):
+        raise NotImplementedError
+
+
+class SQLiteDatabase(DatabaseMixin):
+    def __init__(self, *args,  **kwargs):
+        self.connection = self.connect_to_database(kwargs.get("database_name"), kwargs.get("database_exist"))
+
+    def connect_to_database(self, database_name, database_exist):
+        return sqlite3.connect(f"{SCRIPT_DIR}/{database_name}.db")
+
+    def create_tables(self, queries):
+        cursor = self.connection.cursor()
+        for query in queries:
+            cursor.execute(query)
+
+        self.connection.commit()
+
+    def insert(self, query, data):
+        cursor = self.connection.cursor()
+        cursor.executemany(query, data)
+        self.connection.commit()
+
+
+class MySQLDatabase(DatabaseMixin):
+    def __init__(self, *args,  **kwargs):
+        self.connection = self.connect_to_database(kwargs.get("database_name"), kwargs.get("database_exist"))
+
+    def connect_to_database(self, database_name, database_exist=True):
+        """
+        Connect to database, creating the database if it does't exist.
+
+        :param database_name: str representing database name
+        :param database_exist: bool representing if exists
+        :return: connection: connection to mysql db
+        """
+        try:
+            if database_exist:
+                return connect(
+                    host="localhost",
+                    user=getenv("DATABASE_USER"),
+                    password=getenv("DATABASE_PASSWORD"),
+                    database=database_name,
+                )
+
+            connection = connect(
+                host="localhost",
+                user=getenv("DATABASE_USER"),
+                password=getenv("DATABASE_PASSWORD"),
+            )
+            create_db_query = f"CREATE DATABASE {database_name}"
+            cursor = connection.cursor()
+            cursor.execute(create_db_query)
+            return connection
+
+        except Error as e:
+            print(e)
+
+    def create_tables(self, queries):
+        """
+        :param connection:
+        :param queries:
+        :return:
+        """
+
+        with self.connection.cursor() as cursor:
+            for query in queries:
+                try:
+                    cursor.execute(query)
+
+                except ProgrammingError as e:
+                    if e.errno == 1050:
+                        print("Table exists, continuing")
+                        continue
+                    else:
+                        print(query)
+                        raise ProgrammingError
+
+            self.connection.commit()
+
+    def insert(self, query, data):
+        with self.connection.cursor() as cursor:
+            cursor.executemany(query, data)
+            self.connection.commit()
+
+
+class DatabaseType(Enum):
+    """
+    Enum representing a database type.
+    """
+
+    SQLITE = ("sqlite", SQLiteDatabase)
+    MYSQL = ("mysql", MySQLDatabase)
+
+    @staticmethod
+    def list():
+        """
+        :return: dir of string representations of database type
+        """
+        return dict(map(lambda output: (output.value[0], output.value[1]), DatabaseType))
+
+
+class DatabaseFactory:
+    supported_types = DatabaseType.list()
+
+    @staticmethod
+    def create_database(*args, **kwargs):
+        if kwargs.get("database") not in DatabaseFactory.supported_types.keys():
+            raise NotImplemented(f'Database type {kwargs.get("database")} is not yet supported.')
+
+        cls_obj = DatabaseFactory.supported_types[kwargs.get("database")]
+        obj = cls_obj(*args, **kwargs)
+        return obj

--- a/main.py
+++ b/main.py
@@ -58,34 +58,8 @@ if __name__ == "__main__":
     events = EventbriteScraper.get_events(args.state, args.city, args.category, args.number)
     event_tuples = list(map(lambda e: e.to_tuple(), events))
 
-    table_schema =  """
-    CREATE TABLE events
-             (
-                [id] INTEGER PRIMARY KEY,
-                [url] text,
-                [title] text,
-                [date] text,
-                [time] text,
-                [venue] text,
-                [street_address] text,
-                [city] text,
-                [state] text,
-                [zipcode] int,
-                [map_url] text,
-                [price] text
-             )
-    """
-
-    insert_events_query = """
-                        INSERT INTO `events`
-                            (`url`, `title`, `date`, `time`, `venue`, `street_address`, 
-                            `city`, `state`, `zipcode`, `map_url`, `price`)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """
-
-    db = DatabaseFactory.create_database(**{'database_exist': False, 'database': args.database,  'database_name': 'eventbrite_events'})
-    db.create_tables([table_schema])
-    db.insert(insert_events_query, event_tuples)
+    db = DatabaseFactory.create_database(**{'database_exist': True, 'database': args.database,  'database_name': 'all_events'})
+    db.insert(event_tuples)
 
     counter = 1
     for event in events:

--- a/main.py
+++ b/main.py
@@ -1,0 +1,93 @@
+import argparse
+
+import us
+
+from db import DatabaseFactory
+from scraper import EventbriteScraper
+
+
+def validate_state(state):
+    if state not in us.states.STATES:
+        return argparse.ArgumentTypeError(f'Invalid state: {state}')
+
+    return state
+
+
+def validate_city(city):
+    if len(city) < 1:
+        return argparse.ArgumentTypeError(f'City cannot be empty')
+
+    return city.replace(' ', '-')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Python calculator")
+    parser.add_argument(
+        "category",
+        type=str,
+        help="Select the type of events you'd like to find",
+    )
+    parser.add_argument(
+        "city",
+        type=validate_city,
+        help="Select the city e.g. Chicago.",
+    )
+    parser.add_argument(
+        "state",
+        type=validate_state,
+        help="Select the two letter state e.g. IL.",
+    )
+    parser.add_argument(
+        "-n",
+        "--number",
+        default=20,
+        type=int,
+        help="Number of events you'd like to find, please specify in multiples of 20.",
+    )
+    parser.add_argument(
+        "-d",
+        "--database",
+        default="sqlite",
+        type=str,
+        choices=["sqlite", "mysql"],
+        help="Select either a sqlite or mysql database, by default sqlite is used."
+    )
+
+    args = parser.parse_args()
+
+    events = EventbriteScraper.get_events(args.state, args.city, args.category, args.number)
+    event_tuples = list(map(lambda e: e.to_tuple(), events))
+
+    table_schema =  """
+    CREATE TABLE events
+             (
+                [id] INTEGER PRIMARY KEY,
+                [url] text,
+                [title] text,
+                [date] text,
+                [time] text,
+                [venue] text,
+                [street_address] text,
+                [city] text,
+                [state] text,
+                [zipcode] int,
+                [map_url] text,
+                [price] text
+             )
+    """
+
+    insert_events_query = """
+                        INSERT INTO `events`
+                            (`url`, `title`, `date`, `time`, `venue`, `street_address`, 
+                            `city`, `state`, `zipcode`, `map_url`, `price`)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """
+
+    db = DatabaseFactory.create_database(**{'database_exist': False, 'database': args.database,  'database_name': 'eventbrite_events'})
+    db.create_tables([table_schema])
+    db.insert(insert_events_query, event_tuples)
+
+    counter = 1
+    for event in events:
+        print(f'{counter}. {event.title} on {event.date} {event.time}, event page: {event.url}')
+        counter += 1

--- a/models.py
+++ b/models.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Event:
+    url: str
+    title: str
+    date: str
+    time: str
+    venue: str
+    street_address: str
+    city: str
+    state: str
+    zipcode: int
+    map_url: str
+    price: float
+
+    def to_tuple(self):
+        return (
+            self.url, self.title, self.date, self.time, self.venue, self.street_address,
+            self.city, self.state, self.zipcode, self.map_url, self.price
+        )

--- a/scraper.py
+++ b/scraper.py
@@ -1,47 +1,36 @@
-import argparse
 import pathlib
-import sqlite3
-from dataclasses import dataclass
 
-import requests
-import us
 from bs4 import BeautifulSoup
+import requests
 
+from models import Event
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.absolute()
 EVENTBRITE_URL = 'https://www.eventbrite.com/d'
 
 
-def validate_state(state):
-    if state not in us.states.STATES:
-        return argparse.ArgumentTypeError(f'Invalid state: {state}')
+class EventbriteScraper:
+    @classmethod
+    def get_events(cls, state, city, category, number):
+        page = requests.get(f'{EVENTBRITE_URL}/{state}--{city}/{category}')
+        soup = BeautifulSoup(page.content, 'html.parser')
 
-    return state
+        event_elems = soup.find_all('article',
+                                    class_='eds-l-pad-all-4 eds-event-card-content eds-event-card-content--list '
+                                           'eds-event-card-content--standard eds-event-card-content--fixed')
 
+        for val in range(1, int(number / 20)):
+            page = requests.get(f'{EVENTBRITE_URL}/{category}/?page={val+1}')
+            soup = BeautifulSoup(page.content, 'html.parser')
 
-def validate_city(city):
-    if len(city) < 1:
-        return argparse.ArgumentTypeError(f'City cannot be empty')
+            event_elems += soup.find_all('article',
+                                         class_='eds-l-pad-all-4 eds-event-card-content eds-event-card-content--list '
+                                                'eds-event-card-content--standard eds-event-card-content--fixed')
 
-    return city.replace(' ', '-')
-
-
-@dataclass
-class Event:
-    url: str
-    title: str
-    date: str
-    time: str
-    venue: str
-    street_address: str
-    city: str
-    state: str
-    zipcode: int
-    map_url: str
-    price: float
+        return list(map(lambda e: EventbriteScraper.create_event(e), event_elems))
 
     @classmethod
-    def find_event_details(cls, event):
+    def create_event(cls, event):
         url = event.find('a').attrs.get('href')
         title = event.find('h3').text
 
@@ -79,94 +68,3 @@ class Event:
             url=url, title=title, date=date, time=time, venue=venue, street_address=street_address,
             city=city, state=state, zipcode=zipcode, map_url=map_url, price=price
         )
-
-    def to_tuple(self):
-        return (
-            self.url, self.title, self.date, self.time, self.venue, self.street_address,
-            self.city, self.state, self.zipcode, self.map_url, self.price
-        )
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Python calculator")
-    parser.add_argument(
-        "category",
-        type=str,
-        help="Select the type of events you'd like to find",
-    )
-    parser.add_argument(
-        "city",
-        type=validate_city,
-        help="Select the city e.g. Chicago.",
-    )
-    parser.add_argument(
-        "state",
-        type=validate_state,
-        help="Select the two letter state e.g. IL.",
-    )
-    parser.add_argument(
-        "-n",
-        "--number",
-        default=20,
-        type=int,
-        help="Number of events you'd like to find, please specify in multiples of 20.",
-    )
-
-    args = parser.parse_args()
-
-    page = requests.get(f'{EVENTBRITE_URL}/{args.state}--{args.city}/{args.category}')
-    soup = BeautifulSoup(page.content, 'html.parser')
-
-    event_elems = soup.find_all('article',
-                                class_='eds-l-pad-all-4 eds-event-card-content eds-event-card-content--list '
-                                       'eds-event-card-content--standard eds-event-card-content--fixed')
-
-    for val in range(1,int(args.number / 20)):
-        page = requests.get(f'{EVENTBRITE_URL}/{category}/?page={val+1}')
-        soup = BeautifulSoup(page.content, 'html.parser')
-
-        event_elems += soup.find_all('article',
-                                    class_='eds-l-pad-all-4 eds-event-card-content eds-event-card-content--list '
-                                           'eds-event-card-content--standard eds-event-card-content--fixed')
-
-    events = list(map(lambda e: Event.find_event_details(e), event_elems))
-    events_data = list(map(lambda e: e.to_tuple(), events))
-
-    connection = sqlite3.connect(f"{SCRIPT_DIR}/events.db")
-    cursor = connection.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE events
-                 (
-                    [id] INTEGER PRIMARY KEY,
-                    [url] text,
-                    [title] text,
-                    [date] text,
-                    [time] text,
-                    [venue] text,
-                    [street_address] text,
-                    [city] text,
-                    [state] text,
-                    [zipcode] int,
-                    [map_url] text,
-                    [price] text
-                 )
-        """
-    )
-
-    connection.commit()
-
-    insert_events_query = """
-                INSERT INTO `events`
-                    (`url`, `title`, `date`, `time`, `venue`, `street_address`, 
-                    `city`, `state`, `zipcode`, `map_url`, `price`)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """
-
-    cursor.executemany(insert_events_query, events_data)
-    connection.commit()
-
-    counter = 1
-    for event in events:
-        print(f'{counter}. {event.title} on {event.date} {event.time}, event page: {event.url}')
-        counter += 1


### PR DESCRIPTION
# Overview

This PR refactors `scraper.py` into the following new files as well as adds support for MySQL:

- `models.py` - contains the `Event` dataclass logic
- `db.py`- the `Database` logic which supports both `MySQLDatabase` and `SQLiteDatabase`
- renames `scraper.py` --> `main.py` to contain only the UI logic for the command line interface
- `scraper.py` holds the `EventbriteScraper` logic

The `README.md` includes the updated usage case for database setup as well as MySQL configuration instructions.

## Validation

Ran manually as there are no unit tests at the moment. This can be added in a future PR.