### PR TITLE
Add table namedtuple for DatabaseMixin subtypes to use in tables list and make insert logic more generic

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,13 +1,17 @@
 import pathlib
 import sqlite3
 from abc import abstractmethod
+from collections import namedtuple
 from os import getenv
 
 from enum import Enum
 from mysql.connector import connect, Error, ProgrammingError
 
+from models import Event
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.absolute()
+
+Table = namedtuple("Table", "table_name, fields, schema")
 
 
 class DatabaseMixin:
@@ -16,77 +20,103 @@ class DatabaseMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def create_tables(self, queries):
+    def create_tables(self, tables):
         raise NotImplementedError
 
     @abstractmethod
-    def insert(self, data):
+    def insert(self, table, data):
         raise NotImplementedError
 
 
 class SQLiteDatabase(DatabaseMixin):
     def __init__(self, *args,  **kwargs):
         self.connection = self.connect_to_database(kwargs.get("database_name"), kwargs.get("database_exist"))
-        self.event_table_schema = """CREATE TABLE events
-             (
-                [id] INTEGER PRIMARY KEY,
-                [url] text,
-                [title] text,
-                [date] text,
-                [time] text,
-                [venue] text,
-                [street_address] text,
-                [city] text,
-                [state] text,
-                [zipcode] int,
-                [map_url] text,
-                [price] text
-             )
-        """
-        self.create_tables(queries=[self.event_table_schema])
+        self.tables = {
+            "events": Table(
+                "events",
+                Event.__dataclass_fields__,
+                """CREATE TABLE events
+                (
+                    [id] INTEGER PRIMARY KEY,
+                    [url] text,
+                    [title] text,
+                    [date] text,
+                    [time] text,
+                    [venue] text,
+                    [street_address] text,
+                    [city] text,
+                    [state] text,
+                    [zipcode] int,
+                    [map_url] text,
+                    [price] text
+                )
+            """
+            )
+        }
+        self.create_tables(self.tables)
 
     def connect_to_database(self, database_name, database_exist):
         return sqlite3.connect(f"{SCRIPT_DIR}/{database_name}.db")
 
-    def create_tables(self, queries):
+    def create_tables(self, tables):
+        """
+
+        :param tables: dict of table name to Table namedtuple
+        :return: None
+        """
         cursor = self.connection.cursor()
-        for query in queries:
-            cursor.execute(query)
+        for table_name, table in tables.items():
+            try:
+                cursor.execute(table.schema)
+            except sqlite3.OperationalError as e:
+                if f'table {table_name} already exists' in e.args:
+                    print(f'Table {table_name} exists, continuing')
+                    continue
+                else:
+                    raise e
 
         self.connection.commit()
 
-    def insert(self, data):
-        query =  """
-        INSERT INTO `events`
-            (`url`, `title`, `date`, `time`, `venue`, `street_address`, 
-            `city`, `state`, `zipcode`, `map_url`, `price`)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """
+    def insert(self, table, data):
+        table = self.tables.get(table)
+
+        if not table:
+            raise Exception(f'Table {table} does not exist.')
+
+        fields = f'`{"`,`".join(field for field in table.fields)}`'
+        values = "?, " * (len(table.fields) - 1) + "?"
+
         cursor = self.connection.cursor()
-        cursor.executemany(query, data)
+        cursor.executemany(f"""INSERT INTO `{table.table_name}` ({fields}) VALUES ({values})""", data)
         self.connection.commit()
 
 
 class MySQLDatabase(DatabaseMixin):
     def __init__(self, *args,  **kwargs):
         self.connection = self.connect_to_database(kwargs.get("database_name"), kwargs.get("database_exist"))
-        self.event_table_schema = """
-        CREATE TABLE `events` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
-            `url` TEXT,
-            `title` TEXT,
-            `date` TEXT,
-            `time` TEXT,
-            `venue` TEXT,
-            `street_address` TEXT,
-            `city` TEXT,
-            `state` TEXT,
-            `zipcode` INT(11),
-            `map_url` TEXT,
-            `price` TEXT,
-            PRIMARY KEY (`id`)
-        )"""
-        self.create_tables(queries=[self.event_table_schema])
+        self.tables = {
+            "events": Table(
+                "events",
+                Event.__dataclass_fields__,
+                """
+                CREATE TABLE `events` (
+                    `id` int(11) NOT NULL AUTO_INCREMENT,
+                    `url` TEXT,
+                    `title` TEXT,
+                    `date` TEXT,
+                    `time` TEXT,
+                    `venue` TEXT,
+                    `street_address` TEXT,
+                    `city` TEXT,
+                    `state` TEXT,
+                    `zipcode` INT(11),
+                    `map_url` TEXT,
+                    `price` TEXT,
+                    PRIMARY KEY (`id`)
+                )"""
+            )
+        }
+        self.create_tables(self.tables)
 
     def connect_to_database(self, database_name, database_exist=True):
         """
@@ -118,36 +148,37 @@ class MySQLDatabase(DatabaseMixin):
         except Error as e:
             print(e)
 
-    def create_tables(self, queries):
+    def create_tables(self, tables):
         """
-        :param connection:
-        :param queries:
-        :return:
+
+        :param tables: dict of table name to Table namedtuple
+        :return: None
         """
         with self.connection.cursor() as cursor:
-            for query in queries:
+            for table_name, table in tables.items():
                 try:
-                    cursor.execute(query)
+                    cursor.execute(table.schema)
 
                 except ProgrammingError as e:
                     if e.errno == 1050:
-                        print("Table exists, continuing")
+                        print(f'Table {table_name} exists, continuing')
                         continue
                     else:
-                        print(query)
-                        raise ProgrammingError
+                        raise e
 
             self.connection.commit()
 
-    def insert(self, data):
-        query = """
-        INSERT INTO `events`
-            (`url`, `title`, `date`, `time`, `venue`, `street_address`, 
-            `city`, `state`, `zipcode`, `map_url`, `price`)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+    def insert(self, table, data):
+        table = self.tables.get(table)
+
+        if not table:
+            raise Exception(f'Table {table} does not exist.')
+
+        fields = f'`{"`,`".join(field for field in table.fields)}`'
+        values = "%s, " * (len(table.fields) - 1) + "%s"
 
         with self.connection.cursor() as cursor:
-            cursor.executemany(query, data)
+            cursor.executemany(f"""INSERT INTO `{table.table_name}` ({fields}) VALUES ({values})""", data)
             self.connection.commit()
 
 

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     event_tuples = list(map(lambda e: e.to_tuple(), events))
 
     db = DatabaseFactory.create_database(**{'database_exist': True, 'database': args.database,  'database_name': 'all_events'})
-    db.insert(event_tuples)
+    db.insert("events", event_tuples)
 
     counter = 1
     for event in events:


### PR DESCRIPTION
# Overview

Add `Table` namedtuple for `DatabaseMixin` subtypes to use in tables list and make insert logic more generic,  these changes can be found in:

- `main.py` -  passes an str name representing the table when `db.insert`
- `db.py`- adds `Table` namedtuple for use in the `self.tables` property on the `DatabaseMixin` subtypes as well  as in the. `insert` method

This decouples the `insert` logic permitting any table specified in `self.tables` to have  data inserted.

## Validation

Manually ran both the sqlite and mysql options against `main.py`: `python main.py jazz chicago il -d mysql` and `python main.py jazz chicago il -d sqlite`. Queried data in  databases to confirm data inserted.

Need to still add testing.